### PR TITLE
fix: silabs: security management unit setup

### DIFF
--- a/soc/silabs/common/soc.c
+++ b/soc/silabs/common/soc.c
@@ -198,6 +198,36 @@ static void swo_init(void)
 }
 #endif /* CONFIG_LOG_BACKEND_SWO */
 
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) && !defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
+#if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
+#define PR_EXC(...) LOG_ERR(__VA_ARGS__)
+#else
+#define PR_EXC(...)
+#endif /* CONFIG_PRINTK || CONFIG_LOG */
+
+#if (CONFIG_FAULT_DUMP == 2)
+#define PR_FAULT_INFO(...) PR_EXC(__VA_ARGS__)
+#else
+#define PR_FAULT_INFO(...)
+#endif
+
+static void smu_fault(void)
+{
+	PR_FAULT_INFO("***** SMU FAULT *****");
+
+	if (SMU->IF & SMU_IF_BMPUSEC) {
+		PR_FAULT_INFO("Bus Manager Fault");
+		PR_EXC("SMU.BMPUFS=%d", SMU->BMPUFS);
+	}
+	if (SMU->IF & SMU_IF_PPUSEC) {
+		PR_FAULT_INFO("Peripheral Access Fault");
+		PR_EXC("SMU.PPUFS=%d", SMU->PPUFS);
+	}
+
+	z_fatal_error(K_ERR_CPU_EXCEPTION, NULL);
+}
+#endif
+
 /**
  * @brief Perform basic hardware initialization
  *
@@ -240,6 +270,38 @@ static int silabs_init(void)
 	swo_init();
 #endif
 #endif /* !CONFIG_SOC_GECKO_DEV_INIT */
+
+#if defined(_SILICON_LABS_32B_SERIES_2)
+	/* Initialize TrustZone state of the device.
+	 * If this is a secure app with no non-secure callable functions, it is a secure-only app.
+	 * Configure all peripherals except the SMU and SEMAILBOX to non-secure aliases, and make
+	 * all bus transactions from the CPU have non-secure attribution.
+	 * This makes the secure-only app behave more like a non-secure app, allowing the use of
+	 * libraries that only expect to use non-secure peripherals, such as the radio subsystem.
+	 */
+#if defined(CONFIG_ARM_SECURE_FIRMWARE) && !defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
+#if defined(CMU_CLKEN1_SMU)
+	CMU_S->CLKEN1_SET = CMU_CLKEN1_SMU;
+#endif
+	SMU->PPUSATD0_CLR = _SMU_PPUSATD0_MASK;
+#if defined(SEMAILBOX_PRESENT)
+	SMU->PPUSATD1_CLR = (_SMU_PPUSATD1_MASK & (~SMU_PPUSATD1_SMU & ~SMU_PPUSATD1_SEMAILBOX));
+#else
+	SMU->PPUSATD1_CLR = (_SMU_PPUSATD1_MASK & ~SMU_PPUSATD1_SMU);
+#endif
+
+	SAU->CTRL = SAU_CTRL_ALLNS_Msk;
+	__DSB();
+	__ISB();
+
+	NVIC_ClearPendingIRQ(SMU_SECURE_IRQn);
+	SMU->IF_CLR = SMU_IF_PPUSEC | SMU_IF_BMPUSEC;
+	SMU->IEN = SMU_IEN_PPUSEC | SMU_IEN_BMPUSEC;
+
+	IRQ_DIRECT_CONNECT(SMU_SECURE_IRQn, 0, smu_fault, 0);
+	irq_enable(SMU_SECURE_IRQn);
+#endif
+#endif /* _SILICON_LABS_32B_SERIES_2 */
 
 	return 0;
 }

--- a/soc/silabs/silabs_s2/Kconfig
+++ b/soc/silabs/silabs_s2/Kconfig
@@ -10,4 +10,7 @@ if SOC_FAMILY_SILABS_S2
 
 rsource "*/Kconfig"
 
+config ARM_SECURE_FIRMWARE
+	default y
+
 endif # SOC_FAMILY_SILABS_S2


### PR DESCRIPTION
CMSIS SystemInit is not used in Zephyr. Implement the functionality that isn't already done by Zephyr startup.

The reason the lack of TrustZone init did not create immediately obvious issues previously is that SMU faults can only happen if the SMU clock is enabled.

back-port of https://github.com/zephyrproject-rtos/zephyr/commit/d12de2d6b446