### PR TITLE
drivers: pinctrl: silabs: Fix multiple analogue bus allocation on same port

### DIFF
--- a/drivers/pinctrl/pinctrl_silabs_dbus.c
+++ b/drivers/pinctrl/pinctrl_silabs_dbus.c
@@ -24,8 +24,12 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		if (pins[i].en_bit == SILABS_PINCTRL_ANALOG) {
 			enable_reg = DT_INST_REG_ADDR_BY_NAME(0, abus) +
 				     (pins[i].base_offset * sizeof(mem_addr_t));
-			sys_write32(FIELD_PREP(ABUS_MASK(pins[i].mode), pins[i].route_offset),
-				    enable_reg);
+			/* Read-modify-write. */
+			uint32_t reg_val = sys_read32(enable_reg);
+
+			reg_val &= ~ABUS_MASK(pins[i].mode);
+			reg_val |= FIELD_PREP(ABUS_MASK(pins[i].mode), pins[i].route_offset);
+			sys_write32(reg_val, enable_reg);
 			continue;
 		}
 


### PR DESCRIPTION
Fix ABUS allocation if both EVEN and ODD busses are used for the same port. The initialisation loop would incorrectly overwrite entire GPIO_nBUSALLOC when iterating the pinctrl array, must do a read/mask/update/write sequence.