### PR TITLE
soc: silabs: include system functions in build

### DIFF
--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -144,6 +144,7 @@ zephyr_compile_definitions(
 zephyr_library_sources(
   ${DEVICE_DIR}/SiliconLabs/${SILABS_DEVICE_FAMILY}/Source/system_${CONFIG_SOC_SERIES}.c
   ${EMLIB_DIR}/src/em_system.c
+  ${PERIPHERAL_DIR}/src/sl_hal_system.c
   ${SERVICE_DIR}/clock_manager/src/sl_clock_manager.c
   ${SERVICE_DIR}/clock_manager/src/sl_clock_manager_hal_s2.c
   ${SERVICE_DIR}/clock_manager/src/sl_clock_manager_init.c


### PR DESCRIPTION
Include system support functions for getting information like SoC unique identifier, revision, features, etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `sl_hal_system.c` to Simplicity SDK `zephyr_library_sources` to enable system information functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a37bc17914a39481d6feed4861e2ecbfb40a6612. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->