### PR TITLE
shell: hook for runtime disable of shell

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -11,6 +11,13 @@ menuconfig SHELL_BACKENDS
 
 if SHELL_BACKENDS
 
+config SHELL_BACKEND_ENABLE_HOOK
+	bool "Shell backend enable run-time hook"
+	help
+	  When enabled, shell backends will call an application provided hook
+	  function before they are started. This can be used to disable shell
+	  backends at run time, for example in production firmware builds.
+
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_SHELL_UART := zephyr,shell-uart
 

--- a/subsys/shell/backends/shell_rtt.c
+++ b/subsys/shell/backends/shell_rtt.c
@@ -185,6 +185,14 @@ const struct shell_transport_api shell_rtt_transport_api = {
 
 static int enable_shell_rtt(void)
 {
+#if defined(CONFIG_SHELL_BACKEND_ENABLE_HOOK)
+	extern bool shell_backend_enable_hook(const struct shell *sh);
+
+	if (!shell_backend_enable_hook(&shell_rtt)) {
+		return 0;
+	}
+#endif /* CONFIG_SHELL_BACKEND_ENABLE_HOOK */
+
 	bool log_backend = CONFIG_SHELL_RTT_INIT_LOG_LEVEL > 0;
 	uint32_t level = (CONFIG_SHELL_RTT_INIT_LOG_LEVEL > LOG_LEVEL_DBG) ?
 		      CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_RTT_INIT_LOG_LEVEL;

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -534,6 +534,14 @@ struct smp_shell_data *shell_uart_smp_shell_data_get_ptr(void)
 static int enable_shell_uart(void)
 {
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
+#if defined(CONFIG_SHELL_BACKEND_ENABLE_HOOK)
+	extern bool shell_backend_enable_hook(const struct shell *sh);
+
+	if (!shell_backend_enable_hook(&shell_uart)) {
+		return 0;
+	}
+#endif /* CONFIG_SHELL_BACKEND_ENABLE_HOOK */
+
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	uint32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?


### PR DESCRIPTION
Allow shell RTT and UART backends to be disabled in runtime. Useful to keep shell in build, while still being able to disable it in field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional run-time hook to conditionally enable shell backends, applied to UART and RTT backends before they start.
> 
> - **Shell backends**:
>   - **Kconfig**: Add `CONFIG_SHELL_BACKEND_ENABLE_HOOK` to enable an application-provided hook before starting backends.
>   - **Runtime hook usage**:
>     - `subsys/shell/backends/shell_uart.c`: Call `shell_backend_enable_hook(&shell_uart)` in `enable_shell_uart()`; skip initialization if it returns false.
>     - `subsys/shell/backends/shell_rtt.c`: Call `shell_backend_enable_hook(&shell_rtt)` in `enable_shell_rtt()`; skip initialization if it returns false.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fb6b11522f30fa9bd462d264bdda4b8111a1e37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->